### PR TITLE
Fix a typo

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -1031,7 +1031,7 @@ parse_args (int *argcp,
           char *endptr;
 
           if (argc < 2)
-            die ("--seccomp-fd takes an argument");
+            die ("--seccomp takes an argument");
 
           the_fd = strtol (argv[1], &endptr, 10);
           if (argv[1][0] == 0 || endptr[0] != 0 || the_fd < 0)


### PR DESCRIPTION
The option is called --seccomp, so don't complain about --seccomp-fd
in the error message.